### PR TITLE
feat(swag): setup documentation for api

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -9,7 +9,14 @@ const docTemplate = `{
     "info": {
         "description": "{{escape .Description}}",
         "title": "{{.Title}}",
-        "contact": {},
+        "contact": {
+            "name": "Jason Field",
+            "url": "https://github.com/xorima"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "https://github.com/xorima/webhook-bridge/blob/main/LICENSE"
+        },
         "version": "{{.Version}}"
     },
     "host": "{{.Host}}",
@@ -29,7 +36,7 @@ const docTemplate = `{
                 ],
                 "summary": "This API is there to receive the GitHub events.",
                 "responses": {
-                    "200": {
+                    "202": {
                         "description": "Successful Response",
                         "schema": {
                             "$ref": "#/definitions/app.Response"
@@ -89,17 +96,21 @@ const docTemplate = `{
                 }
             }
         }
+    },
+    "externalDocs": {
+        "description": "GitHub",
+        "url": "https://github.com/xorima/webhook-bridge"
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "",
-	Host:             "",
-	BasePath:         "",
+	Host:             "localhost:3000",
+	BasePath:         "/",
 	Schemes:          []string{},
-	Title:            "",
-	Description:      "",
+	Title:            "Webhook Bridge API",
+	Description:      "This is a bridge to receive various webhook events and publish them to a channel.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,8 +1,19 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "This is a bridge to receive various webhook events and publish them to a channel.",
+        "title": "Webhook Bridge API",
+        "contact": {
+            "name": "Jason Field",
+            "url": "https://github.com/xorima"
+        },
+        "license": {
+            "name": "MIT",
+            "url": "https://github.com/xorima/webhook-bridge/blob/main/LICENSE"
+        }
     },
+    "host": "localhost:3000",
+    "basePath": "/",
     "paths": {
         "/api/v1/webhook/github": {
             "post": {
@@ -18,7 +29,7 @@
                 ],
                 "summary": "This API is there to receive the GitHub events.",
                 "responses": {
-                    "200": {
+                    "202": {
                         "description": "Successful Response",
                         "schema": {
                             "$ref": "#/definitions/app.Response"
@@ -78,5 +89,9 @@
                 }
             }
         }
+    },
+    "externalDocs": {
+        "description": "GitHub",
+        "url": "https://github.com/xorima/webhook-bridge"
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /
 definitions:
   app.Response:
     properties:
@@ -6,8 +7,20 @@ definitions:
       status:
         type: integer
     type: object
+externalDocs:
+  description: GitHub
+  url: https://github.com/xorima/webhook-bridge
+host: localhost:3000
 info:
-  contact: {}
+  contact:
+    name: Jason Field
+    url: https://github.com/xorima
+  description: This is a bridge to receive various webhook events and publish them
+    to a channel.
+  license:
+    name: MIT
+    url: https://github.com/xorima/webhook-bridge/blob/main/LICENSE
+  title: Webhook Bridge API
 paths:
   /api/v1/webhook/github:
     post:
@@ -17,7 +30,7 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
+        "202":
           description: Successful Response
           schema:
             $ref: '#/definitions/app.Response'

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -23,9 +23,9 @@ func NewWebhookHandler(log *slog.Logger) *WebhookHandler {
 //	@Tags			Webhooks
 //	@Accept			json
 //	@Produce		json
-//	@Success		200	{object}	app.Response	"Successful Response"
-//	@Failure		401	{object}	app.Response		"Unauthorized"
-//	@Failure		404	{object}	app.Response		"Failure Response"
+//	@Success		202	{object} Response	"Successful Response"
+//	@Failure		    401	{object} Response	"Unauthorized"
+//	@Failure		  404	{object} Response		"Failure Response"
 //	@Router			/api/v1/webhook/github [post]
 func (wh *WebhookHandler) Post(w http.ResponseWriter, r *http.Request) {
 	wh.log.Info("got request")

--- a/main.go
+++ b/main.go
@@ -2,9 +2,25 @@ package main
 
 import (
 	"github.com/xorima/slogger"
+	"github.com/xorima/webhook-bridge/docs"
 	"github.com/xorima/webhook-bridge/internal/app"
+	"os"
 )
 
+// @title           Webhook Bridge API
+// @description     This is a bridge to receive various webhook events and publish them to a channel.
+
+// @contact.name   Jason Field
+// @contact.url    https://github.com/xorima
+
+// @license.name  MIT
+// @license.url  https://github.com/xorima/webhook-bridge/blob/main/LICENSE
+
+// @host      localhost:3000
+// @BasePath  /
+
+// @externalDocs.description  GitHub
+// @externalDocs.url          https://github.com/xorima/webhook-bridge
 func main() {
 	loggerOpts := slogger.NewLoggerOpts(
 		"github.com/xorima/webhook-bridge",
@@ -12,8 +28,26 @@ func main() {
 	logger := slogger.NewLogger(loggerOpts, slogger.WithLevel("debug"))
 	logger.Info("starting app")
 	h := app.NewApp(logger)
+	docs.SwaggerInfo.Version = getVersion()
+	docs.SwaggerInfo.Host = getHost()
 	err := h.Run()
 	if err != nil {
 		logger.Error("runtime error", slogger.ErrorAttr(err))
 	}
+}
+
+func getVersion() string {
+	v := os.Getenv("VERSION")
+	if len(v) > 1 {
+		return v
+	}
+	return "dev"
+}
+
+func getHost() string {
+	v := os.Getenv("API_HOST")
+	if len(v) > 1 {
+		return v
+	}
+	return "localhost:3000"
 }


### PR DESCRIPTION
This will setup the basic documentation for the API so it appears clearly on the swagger page and openapi docs