### PR TITLE
feat(github): enable end to end github v1

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/go-chi/chi/v5"
 	"github.com/xorima/slogger"
+	"github.com/xorima/webhook-bridge/internal/controllers"
 	"log/slog"
 	"net"
 	"net/http"
@@ -21,7 +22,7 @@ type App struct {
 	router Router
 }
 
-func NewApp(log *slog.Logger) *App {
+func NewApp(log *slog.Logger, controller controllers.Controller) *App {
 	app := &App{
 		port:   3000,
 		router: chi.NewRouter(),
@@ -33,7 +34,7 @@ func NewApp(log *slog.Logger) *App {
 		sh.RegisterRoutes(r)
 		hh.RegisterRoutes(r)
 	})
-	wh := NewWebhookHandler(app.log)
+	wh := NewWebhookHandler(app.log, controller)
 	app.router.Route("/api", func(r Router) {
 		wh.RegisterRoutes(r)
 	})

--- a/internal/controllers/controller.go
+++ b/internal/controllers/controller.go
@@ -1,0 +1,11 @@
+package controllers
+
+import (
+	"context"
+	"io"
+	"net/http"
+)
+
+type Controller interface {
+	Process(ctx context.Context, header http.Header, body io.ReadCloser) error
+}

--- a/internal/controllers/githubController/controller_test.go
+++ b/internal/controllers/githubController/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/stretchr/testify/assert"
 	"github.com/xorima/slogger"
+	"github.com/xorima/webhook-bridge/internal/controllers"
 	"net/http"
 	"testing"
 )
@@ -12,6 +13,9 @@ func TestNewController(t *testing.T) {
 	t.Run("it should create without issue", func(t *testing.T) {
 		c := NewController(slogger.NewDevNullLogger(), newMockProducer(nil))
 		assert.NotNil(t, c.producer)
+	})
+	t.Run("it should implement the controller interface", func(t *testing.T) {
+		assert.Implements(t, (*controllers.Controller)(nil), NewController(slogger.NewDevNullLogger(), newMockProducer(nil)))
 	})
 }
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"github.com/xorima/slogger"
 	"github.com/xorima/webhook-bridge/docs"
 	"github.com/xorima/webhook-bridge/internal/app"
+	"github.com/xorima/webhook-bridge/internal/controllers/githubController"
+	"github.com/xorima/webhook-bridge/internal/data/redisClient"
 	"os"
 )
 
@@ -27,7 +29,11 @@ func main() {
 		"github.com/xorima/webhook-bridge")
 	logger := slogger.NewLogger(loggerOpts, slogger.WithLevel("debug"))
 	logger.Info("starting app")
-	h := app.NewApp(logger)
+	h := app.NewApp(logger,
+		githubController.NewController(logger,
+			redisClient.NewClient("127.0.0.1:6379", "", 0, logger), "local", "webhook", "bridge",
+		),
+	)
 	docs.SwaggerInfo.Version = getVersion()
 	docs.SwaggerInfo.Host = getHost()
 	err := h.Run()


### PR DESCRIPTION
enables the end to end flow of github webhooks which means that you can listen for a webhook and have it successfully delivered to a redis stream successfully.
There is more to be done here though like auth through hmac fan out of the individual topics themselves and additional metadata/attributes on the topics such as merged for pull requests