### PR TITLE
feat(hmac): enable hmac auth for github flow

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 			githubController.NewController(logger,
 				redisClient.NewClient(cfg.RedisConfig(), logger),
 				"local", "webhook", "bridge",
-			),
+			), cfg,
 		)
 		docs.SwaggerInfo.Version = cfg.Version()
 		docs.SwaggerInfo.Host = cfg.Hostname()

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/swaggo/files/v2 v2.0.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/xorima/hmacvalidator v1.0.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/xorima/hmacvalidator v1.0.0 h1:zqhlfMfmo30yCMMNlqfOESFPCJZZMQ+GImuPofJcfKA=
+github.com/xorima/hmacvalidator v1.0.0/go.mod h1:MqcQ05Vy7EfUgBCrTB96jHuXwHN+bMhmDdy/cYUx25g=
 github.com/xorima/slogger v0.0.1 h1:vqP0mrH/hVcbGbVjUwz6tGIKGZnOVTE4M5ccIX9gCV0=
 github.com/xorima/slogger v0.0.1/go.mod h1:wtejpkDXeCz51c2Kj4dv5IlL8+iO6ucSRcjtuoYN3z0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/app/auth_hmac.go
+++ b/internal/app/auth_hmac.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"github.com/xorima/hmacvalidator"
+	"github.com/xorima/slogger"
+	"io"
+	"log/slog"
+	"net/http"
+)
+
+type HmacConfig interface {
+	HmacSecret() string
+	HmacEnabled() bool
+}
+
+type AuthHmac struct {
+	log  *slog.Logger
+	cfg  HmacConfig
+	hash hmacvalidator.Hash
+}
+
+func NewAuthHmacMiddleware(log *slog.Logger, cfg HmacConfig) *AuthHmac {
+	return &AuthHmac{
+		log:  slogger.SubLogger(log, "auth-hmac"),
+		cfg:  cfg,
+		hash: hmacvalidator.HashSha256,
+	}
+}
+
+func (a *AuthHmac) AuthHmacMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !a.cfg.HmacEnabled() {
+			next.ServeHTTP(w, r)
+		}
+		validator := hmacvalidator.NewHMACValidator(hmacvalidator.HashSha256, a.cfg.HmacSecret())
+
+		hmac := r.Header.Get("X-Hub-Signature-256")
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			a.log.WarnContext(r.Context(), "unable to parse body", slogger.ErrorAttr(err))
+			NewResponse(400, "Bad Request").WriteResponse(w)
+		}
+		if validator.IsInvalid(b, hmac) {
+			NewResponse(401, "Unauthorized").WriteResponse(w)
+			return
+		}
+		// If authenticated, proceed to the next handler
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/app/auth_hmac_test.go
+++ b/internal/app/auth_hmac_test.go
@@ -1,0 +1,115 @@
+package app
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"github.com/xorima/slogger"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type MockHmacConfig struct {
+	secret  string
+	enabled bool
+}
+
+func (m *MockHmacConfig) HmacSecret() string {
+	return m.secret
+}
+
+func (m *MockHmacConfig) HmacEnabled() bool {
+	return m.enabled
+}
+
+type mockReader struct {
+}
+
+func (r *mockReader) Read(p []byte) (n int, err error) {
+	return 0, assert.AnError
+}
+
+func TestAuthHmacMiddleware(t *testing.T) {
+	t.Run("it should not check hmac when disabled", func(t *testing.T) {
+		mockCfg := &MockHmacConfig{
+			secret:  "test-secret",
+			enabled: false,
+		}
+		authHmac := NewAuthHmacMiddleware(slogger.NewDevNullLogger(), mockCfg)
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"key":"value"}`))
+		rr := httptest.NewRecorder()
+		handler := authHmac.AuthHmacMiddleware(nextHandler)
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("it should return bad request when body is invalid/cannot be read", func(t *testing.T) {
+		mockCfg := &MockHmacConfig{
+			secret:  "test-secret",
+			enabled: true,
+		}
+		authHmac := NewAuthHmacMiddleware(slogger.NewDevNullLogger(), mockCfg)
+
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/", &mockReader{})
+		rr := httptest.NewRecorder()
+
+		handler := authHmac.AuthHmacMiddleware(nextHandler)
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("it should return 401 when hmac is not valid", func(t *testing.T) {
+		mockCfg := &MockHmacConfig{
+			secret:  "test-secret",
+			enabled: true,
+		}
+		authHmac := NewAuthHmacMiddleware(slogger.NewDevNullLogger(), mockCfg)
+
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"key":"value"}`))
+		req.Header.Set("X-Hub-Signature-256", "invalid-hmac")
+		rr := httptest.NewRecorder()
+
+		handler := authHmac.AuthHmacMiddleware(nextHandler)
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("it should continue to serve when hmac is valid", func(t *testing.T) {
+		mockCfg := &MockHmacConfig{
+			secret:  "test-secret",
+			enabled: true,
+		}
+		authHmac := NewAuthHmacMiddleware(slogger.NewDevNullLogger(), mockCfg)
+
+		nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		body := []byte("hello-world")
+
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+		// https://www.freeformatter.com/hmac-generator.html#before-output
+		req.Header.Set("X-Hub-Signature-256", "sha256=08de25c4a512c01793d703e75503b69a954ecaa1c2fc8917237f8f1e5d5ddd7c")
+		rr := httptest.NewRecorder()
+
+		handler := authHmac.AuthHmacMiddleware(nextHandler)
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}

--- a/internal/app/response.go
+++ b/internal/app/response.go
@@ -1,6 +1,10 @@
 package app
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
 
 type Response struct {
 	Status  int    `json:"status"`
@@ -8,11 +12,18 @@ type Response struct {
 }
 
 func NewResponse(status int, message string) *Response {
-	return &Response{Status: status, Message: message}
+	return &Response{Status: status, Message: strings.ToLower(message)}
 }
 
 func (r *Response) ToJson() []byte {
 	// the error here is impossible due to well known object.
 	resp, _ := json.Marshal(r)
 	return resp
+}
+
+func (r *Response) WriteResponse(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(r.Status)
+	_, _ = w.Write(r.ToJson())
 }

--- a/internal/app/response_test.go
+++ b/internal/app/response_test.go
@@ -1,0 +1,36 @@
+package app
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewResponse(t *testing.T) {
+	t.Run("it should create the response correctly and lowercase the message", func(t *testing.T) {
+		r := NewResponse(200, "Hello world")
+		assert.Equal(t, 200, r.Status)
+		assert.Equal(t, "hello world", r.Message)
+	})
+}
+
+func TestResponse_ToJson(t *testing.T) {
+	t.Run("it should serialize to json correctly", func(t *testing.T) {
+		r := NewResponse(400, "bad request")
+		expectedJSON := `{"status":400,"message":"bad request"}`
+		assert.JSONEq(t, expectedJSON, string(r.ToJson()))
+	})
+}
+
+func TestResponse_WriteResponse(t *testing.T) {
+	t.Run("it should write the response correctly", func(t *testing.T) {
+		r := NewResponse(400, "bad request")
+		rr := httptest.NewRecorder()
+		r.WriteResponse(rr)
+		assert.Equal(t, 400, rr.Code)
+		assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+		assert.Equal(t, "nosniff", rr.Header().Get("X-Content-Type-Options"))
+		expectedJSON := `{"status":400,"message":"bad request"}`
+		assert.JSONEq(t, expectedJSON, rr.Body.String())
+	})
+}

--- a/internal/app/webhook.go
+++ b/internal/app/webhook.go
@@ -38,6 +38,7 @@ func (wh *WebhookHandler) Post(w http.ResponseWriter, r *http.Request) {
 		wh.log.ErrorContext(r.Context(), "failure during processing of event", slogger.ErrorAttr(err))
 		resp = NewResponse(http.StatusBadRequest, "Bad Request")
 	}
+	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(resp.Status)
 	_, err = w.Write(resp.ToJson())
 	if err != nil {
@@ -45,6 +46,6 @@ func (wh *WebhookHandler) Post(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (wh *WebhookHandler) RegisterRoutes(r Router) {
-	r.Post("/v1/webhook/github", wh.Post)
+func (wh *WebhookHandler) RegisterRoutes(r Router, hmac *AuthHmac) {
+	r.With(hmac.AuthHmacMiddleware).Post("/v1/webhook/github", wh.Post)
 }


### PR DESCRIPTION
github gives us the option to use hmac auth for their flow, so we should enable this to be sure of the source of truth for our webhooks and if they are from where we expect them to be from