### PR TITLE
test(routes): add tests for basic static routes

### DIFF
--- a/internal/app/health.go
+++ b/internal/app/health.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/xorima/slogger"
 	"log/slog"
 	"net/http"
 )
@@ -25,12 +24,7 @@ func NewHealthHandler(log *slog.Logger) *HealthHandler {
 //	@Router			/healthz [get]
 func (h *HealthHandler) Get(w http.ResponseWriter, r *http.Request) {
 	h.log.InfoContext(r.Context(), "returning health check", slog.String("user-agent", r.UserAgent()))
-	resp := NewResponse(http.StatusOK, "Healthy")
-	w.WriteHeader(resp.Status)
-	_, err := w.Write(resp.ToJson())
-	if err != nil {
-		h.log.ErrorContext(r.Context(), "failure in writing health status", slogger.ErrorAttr(err))
-	}
+	NewResponse(http.StatusOK, "Healthy").WriteResponse(w)
 }
 
 func (h *HealthHandler) RegisterRoutes(r Router) {

--- a/internal/app/health_test.go
+++ b/internal/app/health_test.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/xorima/slogger"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthHandler_RegisterRoutes(t *testing.T) {
+	router := chi.NewRouter()
+	healthHandler := NewHealthHandler(slogger.NewDevNullLogger())
+	healthHandler.RegisterRoutes(router)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.JSONEq(t, `{"status":200,"message":"healthy"}`, rr.Body.String())
+}

--- a/internal/app/swagger_test.go
+++ b/internal/app/swagger_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/xorima/slogger"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSwaggerHandler_Redirect(t *testing.T) {
+	t.Run("it should redirect the  given path the swagger ui", func(t *testing.T) {
+		swaggerHandler := NewSwaggerHandler(slogger.NewDevNullLogger())
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rr := httptest.NewRecorder()
+		swaggerHandler.Redirect(rr, req)
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, "/swagger/", rr.Header().Get("Location"))
+	})
+}
+func TestSwaggerHandler_RegisterRoutes(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "it should redirect / to the swagger ui",
+			path: "/",
+		},
+		{
+			name: "it should redirect /swagger to the swagger ui",
+			path: "/swagger",
+		},
+		{
+			name: "it should redirect /swagger-ui to the swagger ui",
+			path: "/swagger-ui",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := chi.NewRouter()
+			swaggerHandler := NewSwaggerHandler(slogger.NewDevNullLogger())
+			swaggerHandler.RegisterRoutes(router)
+
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusFound, rr.Code)
+			assert.Equal(t, "/swagger/", rr.Header().Get("Location"))
+		})
+	}
+	t.Run("it should load the swagger ui", func(t *testing.T) {
+		router := chi.NewRouter()
+		swaggerHandler := NewSwaggerHandler(slogger.NewDevNullLogger())
+		swaggerHandler.RegisterRoutes(router)
+		req := httptest.NewRequest(http.MethodGet, "/swagger/", nil)
+		rr := httptest.NewRecorder()
+
+		router.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusMovedPermanently, rr.Code)
+		// this is a path mounted directly on the swagger ui that we do not control
+		assert.Equal(t, "/swagger/index.html", rr.Header().Get("Location"))
+	})
+
+}


### PR DESCRIPTION
As our routes are starting to look a bit more static and a lot more set in their ways, this will add the initial basic tests for the simple routes to get us on the journey.
the other routes will be tested via a replay system of real calls with headers to check we get the same results over time