### PR TITLE
feat(github): have a seperate topic per event type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ docs:
 	swag init
 
 run: docs test
-	go run .
+	GITHUB_HMAC_ENABLED=false go run .
 
 lint:
 	docker run --rm -v $(shell pwd):/app -v ~/.cache/golangci-lint/v1.61.0:/root/.cache -w /app golangci/golangci-lint:v1.61.0 golangci-lint run

--- a/internal/controllers/githubController/controller_test.go
+++ b/internal/controllers/githubController/controller_test.go
@@ -41,13 +41,13 @@ func TestController_Process(t *testing.T) {
 	})
 	t.Run("it should publish the body to the correct queue", func(t *testing.T) {
 		p := newMockProducer(nil)
-		c := NewController(slogger.NewDevNullLogger(), p)
+		c := NewController(slogger.NewDevNullLogger(), p, "test", "webhook", "bridge")
 		headers := http.Header{}
-		headers.Add(githubEventHeader, "pull-request")
+		headers.Add(githubEventHeader, "pullRequest")
 		err := c.Process(context.Background(), headers, NewMockBody("hello world"))
 		assert.NoError(t, err)
 		assert.Equal(t, "hello world", p.event.Body)
-		assert.Equal(t, "pull-request", p.event.Attributes[0].Value)
-		assert.Equal(t, "github-events", p.channel.Name)
+		assert.Equal(t, "pull-request", p.channel.Name)
+		assert.Equal(t, []string{"test", "webhook", "bridge", "github"}, p.channel.Prefix)
 	})
 }

--- a/internal/data/topic/channel.go
+++ b/internal/data/topic/channel.go
@@ -13,6 +13,6 @@ func NewChannel(name string) *Channel {
 // this will be used by the event sender to set the correct
 // named channel based on the end system's naming rules.
 func (c *Channel) WithPrefix(prefix ...string) *Channel {
-	c.Prefix = prefix
+	c.Prefix = append(c.Prefix, prefix...)
 	return c
 }


### PR DESCRIPTION
We will want to subscribe to some events but not all in our systems so this will enable us to fan them out based on the event type. We will need to figure out the attributes we want on each type of event which will drive us to the right information at the right time. for example we want to know action and actor for pull request