### PR TITLE
ci(build): create the binaries to ensure compile works

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,28 @@ jobs:
           check-modified-files-only: "yes"
           base-branch: "main"
           file-path: ''
+
+  build:
+    name: Build Golang Binaries
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos:
+          - "linux"
+          - "windows"
+          - "darwin"
+        goarch:
+          - "amd64"
+          - "arm64"
+        exclude:
+          - goarch: "arm64"
+            goos: "windows"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+      - name: Run build
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o bin/webhook-bridge-${{ matrix.goos }}-${{ matrix.goarch }} main.go

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: local
     hooks:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,4 +1,9 @@
+---
 extends: default
 
 ignore:
   - "docs/"
+
+rules:
+  line-length:
+    max: 160


### PR DESCRIPTION
Creates the binaries for every OS we want to support to ensure they continue to function